### PR TITLE
Solution stability

### DIFF
--- a/src/leave_out_correction.jl
+++ b/src/leave_out_correction.jl
@@ -726,6 +726,8 @@ function eff_res(lev::JLAAlgorithm, X,first_id,second_id,match_id, K, settings)
         Fvar= hcat(spzeros(NT,N), X[:,N+1:N+J-1])
         Dvar=hcat(X[:,1:N], spzeros(NT,J-1))
 
+        (settings.print_level > 0) && println("Running JLA with ",p," simulations.")
+
         Threads.@threads for i=1:p
             #Draw Rademacher entry
             rademach[Threads.threadid(),:] =  rand(1,NT) .> 0.5

--- a/src/leave_out_correction.jl
+++ b/src/leave_out_correction.jl
@@ -673,7 +673,7 @@ function eff_res(lev::JLAAlgorithm, X,first_id,second_id,match_id, K, settings)
     compute_sol = []
     for i in 1:Threads.nthreads()
         P = approxcholOperator(ldli,buffs[:,i])
-        push!(compute_sol,approxcholSolver(P,la))
+        push!(compute_sol,approxcholSolver(P,la;tol=1e-12))
     end
 
     #Initialize output

--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -24,7 +24,7 @@ function approxcholSolver(P::PreallocatedLinearOperator, la::AbstractArray; tol:
     verbose_=verbose
 
     f = function(b;tol=tol_, maxits=maxits_, verbose=verbose_)
-        xaug = Krylov.cg(la,[b; -sum(b)] .- mean([b; -sum(b)]), M=P, rtol = tol, itmax=maxits, verbose=verbose)[1]
+        xaug = Krylov.cg(la,[b; -sum(b)] .- mean([b; -sum(b)]), M=P, rtol = tol, itmax=maxits, verbose=true)[1]
         xaug .= xaug .- xaug[end]
         return xaug[1:end-1]
     end

--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -24,7 +24,7 @@ function approxcholSolver(P::PreallocatedLinearOperator, la::AbstractArray; tol:
     verbose_=verbose
 
     f = function(b;tol=tol_, maxits=maxits_, verbose=verbose_)
-        xaug = Krylov.cg(la,[b; -sum(b)] .- mean([b; -sum(b)]), M=P, rtol = tol, itmax=maxits, verbose=true)[1]
+        xaug = Krylov.cg(la,[b; -sum(b)] .- mean([b; -sum(b)]), M=P, rtol = tol, itmax=maxits, verbose=false)[1]
         xaug .= xaug .- xaug[end]
         return xaug[1:end-1]
     end
@@ -44,7 +44,7 @@ function approxcholSolver(ldli::LDLinv, la::AbstractArray; tol::Real=1e-6, maxit
     verbose_=verbose
 
     f = function(b;tol=tol_, maxits=maxits_, verbose=verbose_)
-        xaug = Krylov.cg(la,[b; -sum(b)] .- mean([b; -sum(b)]), M=P, rtol = tol, itmax=maxits, verbose=verbose)[1]
+        xaug = Krylov.cg(la,[b; -sum(b)] .- mean([b; -sum(b)]), M=P, rtol = tol, itmax=maxits, verbose=false)[1]
         xaug .= xaug .- xaug[end]
         return xaug[1:end-1]
     end
@@ -68,7 +68,7 @@ function approxcholSolver(sddm::AbstractArray; tol::Real=1e-6, maxits=300, verbo
     verbose_=verbose
 
     f = function(b;tol=tol_, maxits=maxits_, verbose=verbose_)
-        xaug = Krylov.cg(la,[b; -sum(b)] .- mean([b; -sum(b)]), M=P, rtol = tol, itmax=maxits, verbose=verbose)[1]
+        xaug = Krylov.cg(la,[b; -sum(b)] .- mean([b; -sum(b)]), M=P, rtol = tol, itmax=maxits, verbose=false)[1]
         xaug .= xaug .- xaug[end]
         return xaug[1:end-1]
     end

--- a/test/test_matrices.jl
+++ b/test/test_matrices.jl
@@ -175,9 +175,14 @@ end
         @unpack θ_first, θ_second, θCOV, β, Dalpha, Fpsi, Pii, Bii_first, Bii_second, Bii_cov = leave_out_estimation(y,first_id,second_id,controls,settings_JLA)
     
 
-        # println("θ_second: $θ_second \n θ_first:$θ_first \n, θCOV: $θCOV \n obs: $obs \n β: $β \n Dalpha: $Dalpha \n Fpsi: $Fpsi \n Pii: $Pii \n Bii_first: $Bii_first \n Bii_second: $Bii_second \n Bii_cov: $Bii_cov \n")
-        @test β ≈ [0.2313735, 0.5076485000000001, 0.6847255, 0.4198749, 0.019589999999999996]
-        @test isapprox([θ_second, θ_first, θCOV] ,  [-0.0045945419556785785, 0.00592537744258884, -0.0023531073877489203], atol=1e-1) #Rewrite this
+        println("θ_second: $θ_second \n θ_first:$θ_first \n, θCOV: $θCOV \n obs: $obs \n β: $β \n Dalpha: $Dalpha \n Fpsi: $Fpsi \n Pii: $Pii \n Bii_first: $Bii_first \n Bii_second: $Bii_second \n Bii_cov: $Bii_cov \n")
+        # @test β ≈ [0.2313735, 0.5076485000000001, 0.6847255, 0.4198749, 0.019589999999999996]
+        @test isapprox([θ_second, θ_first, θCOV] ,  [-0.17707507536052222, -0.17145102440488802, 0.10101283333196641], atol=1e-1) #Rewrite this
+
+        @test Pii ≈ diag(diagm([0.99, 0.99, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]))
+        @test isapprox(Bii_first, diag(diagm([0.770833, 1.10417, 0.375, 0.375, 0.604167, 0.270833, 0.375, 0.375])), atol = 1e-4)	
+        @test isapprox(Bii_second, diag(diagm([1.41667, 1.41667, 0, 0, 1.41667, 1.41667, 0, 0])), atol = 1e-4)	
+        @test isapprox(Bii_cov, diag(diagm([-0.625, -0.708333, 0, 0, -0.791667, -0.541667, 0, 0])), atol = 1e-4)
     end
     @testset "JLA Algorithm with three simulations, person and cov effects = false" begin
         Random.seed!(1234)
@@ -191,9 +196,14 @@ end
         @unpack θ_first, θ_second, θCOV, β, Dalpha, Fpsi, Pii, Bii_first, Bii_second, Bii_cov = leave_out_estimation(y,first_id,second_id,controls,settings_JLA)
     
 
-        # println("θ_second: $θ_second \n θ_first:$θ_first \n, θCOV: $θCOV \n obs: $obs \n β: $β \n Dalpha: $Dalpha \n Fpsi: $Fpsi \n Pii: $Pii \n Bii_first: $Bii_first \n Bii_second: $Bii_second \n Bii_cov: $Bii_cov \n")
-        @test β ≈ [0.2313735, 0.5076485000000001, 0.6847255, 0.4198749, 0.019589999999999996]
-        @test isapprox(θ_second ,  -0.0014584152995119073, atol=1e-2) #Rewrite this
+        println("θ_second: $θ_second \n θ_first:$θ_first \n, θCOV: $θCOV \n obs: $obs \n β: $β \n Dalpha: $Dalpha \n Fpsi: $Fpsi \n Pii: $Pii \n Bii_first: $Bii_first \n Bii_second: $Bii_second \n Bii_cov: $Bii_cov \n")
+        # @test β ≈ [0.2313735, 0.5076485000000001, 0.6847255, 0.4198749, 0.019589999999999996]
+        @test isapprox(θ_second ,  -0.17707507536052222, atol=1e-2) #Rewrite this
+
+        @test Pii ≈ diag(diagm([0.99, 0.99, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]))	
+        @test isequal(Bii_first, nothing)	
+        @test isapprox(Bii_second, diag(diagm([1.41667, 1.41667, 0, 0, 1.41667, 1.41667, 0, 0])), atol = 1e-4)	
+        @test isequal(Bii_cov,nothing)
 
     end
 end


### PR DESCRIPTION
Proposing the following changes: 

1. There was some instability in the JLA solutions (was found when increasing the number of simulations to very high numbers). I found that the source of this was that the three JLA solutions and the computations of Pii and Bii that come from it were not working in a thread-safe manner. The solution involves pre-allocating vectors (for each thread) that contain the rademacher entries, and the three JLA solutions. 

2. Provide a first step towards new unit tests for the JLA algorithm under changes in 1.  Furthermore, I'm including an option to run the whole JLA algorithm on `test.csv` by changing an environment variable to true. 

3. Fix a line that didn't update to the new heuristic number of simulations (i.e. 100 times log(#total fixed effects) ).

4. Add a println line that indicates the number of JLA repetitions when `print_level>0`. 

5. Verbosity of `Krylov.cg` solver prints too much stuff and looks super clunky when it interacts with multi-threading, so I set it to `false` always. 