### PR TITLE
Include Linear Combination Inference 

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -12,6 +12,18 @@ git-tree-sha1 = "2b6845cea546604fb4dca4e31414a6a59d39ddcd"
 uuid = "ec485272-7323-5ecc-a04f-4719b315124d"
 version = "0.0.4"
 
+[[Arpack]]
+deps = ["Arpack_jll", "Libdl", "LinearAlgebra"]
+git-tree-sha1 = "2ff92b71ba1747c5fdd541f8fc87736d82f40ec9"
+uuid = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
+version = "0.4.0"
+
+[[Arpack_jll]]
+deps = ["Libdl", "OpenBLAS_jll", "Pkg"]
+git-tree-sha1 = "e214a9b9bd1b4e1b4f15b22c0994862b66af7ff7"
+uuid = "68821587-b530-5797-8361-c406ea357684"
+version = "3.5.0+3"
+
 [[ArtifactUtils]]
 deps = ["Pkg", "SHA"]
 git-tree-sha1 = "365f3d6e14acb92aa8f082208621439ed2d2aa4d"
@@ -149,10 +161,10 @@ uuid = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 version = "0.13.5"
 
 [[HDF5_jll]]
-deps = ["Libdl", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "3dbc683172cb53428907485a4bb98a29d3874083"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "bc9c3d43ffd4d8988bfa372b86d4bdbd26860e95"
 uuid = "0234f1f7-429e-5d53-9886-15a909be8d59"
-version = "1.10.5+6"
+version = "1.10.5+7"
 
 [[Inflate]]
 git-tree-sha1 = "f5fc07d4e706b84f72d54eedcc1c13d92fb0871c"
@@ -247,6 +259,12 @@ version = "0.4.4"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[OpenBLAS_jll]]
+deps = ["CompilerSupportLibraries_jll", "Libdl", "Pkg"]
+git-tree-sha1 = "0c922fd9634e358622e333fc58de61f05a048492"
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.9+5"
 
 [[OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
+Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
 ArtifactUtils = "8b73e784-e7d8-4ea5-973d-377fed4e3bce"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/src/VarianceComponentsHDFE.jl
+++ b/src/VarianceComponentsHDFE.jl
@@ -8,6 +8,7 @@ using SparseArrays, LightGraphs, DataFramesMeta
 using Distributions
 using LinearOperators, FastClosures, Krylov
 using ArgParse
+using Arpack
 
 #include("init.jl")
 include("leave_out_correction.jl")

--- a/src/VarianceComponentsHDFE.jl
+++ b/src/VarianceComponentsHDFE.jl
@@ -21,6 +21,7 @@ export find_connected_set,prunning_connected_set,drop_single_obs, index_constr
 export compute_movers, check_clustering, eff_res
 export do_Pii, lincom_KSS, compute_matchid, leave_out_estimation, get_leave_one_out_set
 export VCHDFESettings, JLAAlgorithm, ExactAlgorithm, AbstractLeverageAlgorithm
+export compute_whole, lincom_KSS
 
 # Exporting these functions for ease of benchmarking/testing
 export computeLDLinv, approxcholOperator, approxcholSolver

--- a/src/leave_out_correction.jl
+++ b/src/leave_out_correction.jl
@@ -1097,7 +1097,7 @@ function compute_whole(y,first_id,second_id,controls,settings::VCHDFESettings)
 end
 
 
-function lincom_KSS(df,y,X, β, regressors,Pii, obs_id; fixed_effects=1, joint_test =false, joint_test_regressors = nothing, nsim = 10000, settings = settings)
+function lincom_KSS(df,y,first_id, second_id, β, regressors,Pii, obs_id; fixed_effects=1, joint_test =false, joint_test_regressors = nothing, nsim = 10000, settings = settings)
     #regressors is a vector of strings
     labels = regressors
 

--- a/src/leave_out_correction.jl
+++ b/src/leave_out_correction.jl
@@ -1097,7 +1097,7 @@ function compute_whole(y,first_id,second_id,controls,settings::VCHDFESettings)
 end
 
 
-function lincom_KSS(df,y,first_id, second_id, β, regressors,Pii, obs_id; fixed_effects=1, joint_test =false, joint_test_regressors = nothing, nsim = 10000, settings = settings)
+function lincom_KSS(df,y,first_id, second_id, β, regressors,Pii, obs_id; fixed_effects=1, joint_test =false, joint_test_regressors = nothing, nsim = 10000)
     #regressors is a vector of strings
     labels = regressors
 

--- a/src/leave_out_correction.jl
+++ b/src/leave_out_correction.jl
@@ -1185,7 +1185,7 @@ function lincom_KSS(df,y,X, β, regressors,Lambda_P, obs_id; fixed_effects=1, jo
 
 
     # PART 5: Joint-test. Quadratic form beta'*A*beta
-    if joint_test == true
+    if joint_test_regressors == true
 
         if restrict  == nothing
             restrict=sparse(collect(1:r-1),collect(2:r),1.0,r-1,r)

--- a/src/leave_out_correction.jl
+++ b/src/leave_out_correction.jl
@@ -1210,7 +1210,7 @@ function lincom_KSS(df,y,first_id, second_id, β, regressors,Pii, obs_id; fixed_
 
 
     # PART 5: Joint-test. Quadratic form beta'*A*beta
-    if joint_test ==false |  (joint_test_regressors != nothing )
+    if joint_test ==false &  (joint_test_regressors != nothing )
         println("Joint test will not be computed. You need to set the argument option joint_test to true.")
     end
 

--- a/src/leave_out_correction.jl
+++ b/src/leave_out_correction.jl
@@ -1210,7 +1210,11 @@ function lincom_KSS(df,y,X, β, regressors,Pii, obs_id; fixed_effects=1, joint_t
 
 
     # PART 5: Joint-test. Quadratic form beta'*A*beta
-    if joint_test == true | joint_test_regressors != nothing 
+    if joint_test ==false | joint_test_regressors != nothing 
+        println("Joint test will not be computed. You need to set the argument option joint_test to true.")
+    end
+
+    if joint_test == true 
 
         if joint_test_regressors  == nothing
             restrict=sparse(collect(1:r-1),collect(2:r),1.0,r-1,r)

--- a/src/leave_out_correction.jl
+++ b/src/leave_out_correction.jl
@@ -1210,7 +1210,7 @@ function lincom_KSS(df,y,first_id, second_id, β, regressors,Pii, obs_id; fixed_
 
 
     # PART 5: Joint-test. Quadratic form beta'*A*beta
-    if joint_test ==false | joint_test_regressors != nothing 
+    if joint_test ==false |  (joint_test_regressors != nothing )
         println("Joint test will not be computed. You need to set the argument option joint_test to true.")
     end
 

--- a/src/leave_out_correction.jl
+++ b/src/leave_out_correction.jl
@@ -1081,7 +1081,7 @@ function compute_whole(y,first_id,second_id,controls,settings::VCHDFESettings)
 end
 
 
-function lincom_KSS(y,X,Z,Transform,Lambda_P; joint_test =false, labels=nothing, restrict=nothing, nsim = 10000, settings = settings)
+function lincom_KSS(y,X,Z, beta,Transform,Lambda_P; joint_test =false, labels=nothing, restrict=nothing, nsim = 10000, settings = settings)
     #SET DIMENSIONS
     n=size(X,1)
     K=size(X,2)
@@ -1089,10 +1089,6 @@ function lincom_KSS(y,X,Z,Transform,Lambda_P; joint_test =false, labels=nothing,
     Z=hcat(ones(size(Z,1)), Z)
 
     # PART 1: ESTIMATE HIGH DIMENSIONAL MODEL
-    xx=X'*X
-    xy=X'*y
-    compute_sol = approxcholSolver(xx;verbose = settings.print_level > 0)
-    beta = compute_sol([xy...];verbose=false)
     eta=y-X*beta
 
     # PART 1B: VERIFY LEAVE OUT COMPUTATION

--- a/src/leave_out_correction.jl
+++ b/src/leave_out_correction.jl
@@ -1081,7 +1081,7 @@ function compute_whole(y,first_id,second_id,controls,settings::VCHDFESettings)
 end
 
 
-function lincom_KSS(y,X,Z,Transform,clustering_var,Lambda_P; joint_test =false, labels=nothing, restrict=nothing, nsim = 10000, settings = settings)
+function lincom_KSS(y,X,Z,Transform,Lambda_P; joint_test =false, labels=nothing, restrict=nothing, nsim = 10000, settings = settings)
     #SET DIMENSIONS
     n=size(X,1)
     K=size(X,2)
@@ -1096,20 +1096,6 @@ function lincom_KSS(y,X,Z,Transform,clustering_var,Lambda_P; joint_test =false, 
     eta=y-X*beta
 
     # PART 1B: VERIFY LEAVE OUT COMPUTATION
-    if Lambda_P == nothing
-        Lambda_P=do_Pii(X,clustering_var)
-    end
-
-    if Lambda_P != nothing && clustering_var !=nothing
-        nnz_1=nnz(Lambda_P)
-        nnz_2=check_clustering(clustering_var).nnz_2
-
-        if nnz_1 == nnz_2
-            println("The structure of the specified Lambda_P is consistent with the level of clustering required by the user.")
-        elseif nnz_1 != nnz_2
-            error("The user wants cluster robust inference but the Lambda_P provided by the user is not consistent with the level of clustering asked by the user. Try to omit input Lambda_P when running lincom_KSS")
-        end
-    end
     I_Lambda_P = I-Lambda_P
     eta_h = I_Lambda_P\eta
 

--- a/test/test_matrices.jl
+++ b/test/test_matrices.jl
@@ -14,6 +14,19 @@ run_full_test = get(ENV, "JLA_TESTCSV", "false")  == "true" ? true : false
 pkg_dir = pkgdir(VarianceComponentsHDFE)
 
 
+@testset "compute_whole" begin
+    #Full Network
+    y_full = [0.146297; 0.29686 ;  0.54344; 0.432677 ; 0.464866 ; 0.730622 ; 0.619239; 0.753429; 0.0863208; 0.372084 ;  0.958089]
+    id_full = [1; 1; 2;2 ; 3; 4;4 ;5;5 ;6;6]
+    firmid_full = [1;2;1;1;1;1;2;2;2;2;3]
+    obs_id_full = collect(1:11)
+
+    @unpack θ_first, θ_second, θCOV, obs_id, β, Dalpha, Fpsi, Pii, Bii_first, Bii_second, Bii_cov, y, N = compute_whole(y_full, id_full, firmid_full, nothing, VCHDFESettings(print_level = 1))
+
+    @test 1 == 1    
+end
+
+
 @testset "PruneNetwork" begin
     #Full Network
     y_full = [0.146297; 0.29686 ;  0.54344; 0.432677 ; 0.464866 ; 0.730622 ; 0.619239; 0.753429; 0.0863208; 0.372084 ;  0.958089]


### PR DESCRIPTION
We're adding the function `lincom_KSS()`, which provides inference on linear combinations as a post-estimation command. It has the option to run a regression of some covariates Z against either a) estimated firm fixed effects, or b) estimated worker effects. It provides the t-test for every covariate, and it has the option to provide a joint-test on a subset of these regressors. 

